### PR TITLE
feat: support configuration

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -7,21 +7,39 @@ describe('createStubSourcegraphAPI()', () => {
         const stub = createStubSourcegraphAPI()
         assert(stub)
     })
-    it('should support creating unique decorationTypes', () => {
-        const stub = createStubSourcegraphAPI()
-        assert.deepStrictEqual(stub.app.createDecorationType(), { key: 'decorationType0' })
-        assert.deepStrictEqual(stub.app.createDecorationType(), { key: 'decorationType1' })
-        assert.deepStrictEqual(stub.app.createDecorationType(), { key: 'decorationType2' })
+    describe('app', () => {
+        it('should support creating unique decorationTypes', () => {
+            const stub = createStubSourcegraphAPI()
+            assert.deepStrictEqual(stub.app.createDecorationType(), { key: 'decorationType0' })
+            assert.deepStrictEqual(stub.app.createDecorationType(), { key: 'decorationType1' })
+            assert.deepStrictEqual(stub.app.createDecorationType(), { key: 'decorationType2' })
+        })
     })
-
-    // TODO fix Position/Range classes (publish as package) and MarkupKind enum assignability
-    // it('should allow registering a hover provider', () => {
-    //     const stub = createStubSourcegraphAPI()
-    //     stub.languages.registerHoverProvider(['*.ts'], {
-    //         provideHover: (doc, pos) => ({
-    //             contents: { kind: stub.MarkupKind.Markdown, value: doc.uri },
-    //             range: new stub.Range(new stub.Position(1, 2), new stubs.Position(3, 4)),
-    //         }),
+    describe('configuration', () => {
+        it('should support reading configuration', async () => {
+            const stub = createStubSourcegraphAPI()
+            assert.deepStrictEqual(stub.configuration.get().value, {})
+            const listener = sinon.spy()
+            stub.configuration.subscribe(listener)
+            sinon.assert.calledOnce(listener)
+            assert.deepStrictEqual(listener.args[0][0], undefined)
+            await stub.configuration.get().update('foo', 'bar')
+            assert.deepStrictEqual(stub.configuration.get().value, { foo: 'bar' })
+            assert.deepStrictEqual(stub.configuration.get().get('foo'), 'bar')
+            sinon.assert.calledTwice(listener)
+            assert.deepStrictEqual(listener.args[1][0], undefined)
+        })
+    })
+    // describe('languages', () => {
+    //     // TODO fix Position/Range classes (publish as package) and MarkupKind enum assignability
+    //     it('should allow registering a hover provider', () => {
+    //         const stub = createStubSourcegraphAPI()
+    //         stub.languages.registerHoverProvider(['*.ts'], {
+    //             provideHover: (doc, pos) => ({
+    //                 contents: { kind: stub.MarkupKind.Markdown, value: doc.uri },
+    //                 range: new stub.Range(new stub.Position(1, 2), new stubs.Position(3, 4)),
+    //             }),
+    //         })
     //     })
     // })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@sourcegraph/tsconfig",
   "compilerOptions": {
-    "target": "es2016",
+    "target": "es2018",
     "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4711,7 +4711,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.10.0, resolve@^1.3.2, resolve@^1.4.0:
+resolve@^1.3.2, resolve@^1.4.0:
   version "1.10.1"
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz#664842ac960795bbe758221cdccda61fb64b5f18"
   integrity sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==


### PR DESCRIPTION
Stubs out `sourcegraph.configuration`.
Config can be set through the API's `update()` method.